### PR TITLE
Release Notes for 4.4.407 

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -17,11 +17,11 @@ AppDynamics APM supports performance monitoring of application metrics. AppDynam
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v4.4.358</td>
+        <td>v4.4.407</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>August 15, 2018</td>
+        <td>August 28, 2018</td>
     </tr>       
     <tr>        
         <td>Pivotal Cloud Foundry Operations Manager </td>      

--- a/docs-content/release_notes.html.md.erb
+++ b/docs-content/release_notes.html.md.erb
@@ -5,6 +5,14 @@ owner: Partners
 
 <p class="note"><strong>Note:</strong> Upgrades from AppDynamics v1.x are not supported. If you previously installed AppDynamics v1.x, uninstall it and install the latest version.</p>
 
+## <a id='44407'></a> 4.4.358
+
+**Release Date:** August 28, 2018
+
+- Maintenance release
+- Analytics Agent uses offline Java buildpack to cater cloudfoundry installations that donot have access to GitHub to fetch buildpacks on the fly
+
+
 
 ## <a id='44358'></a> 4.4.358
 


### PR DESCRIPTION
## <a id='44407'></a> 4.4.358

**Release Date:** August 28, 2018

- Maintenance release
- Analytics Agent uses offline Java buildpack to cater cloudfoundry installations that donot have access to GitHub to fetch buildpacks on the fly
