### PR TITLE
AppDynamics APM v4.7.81 release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -35,11 +35,11 @@ and [language-specific workflows](https://docs.pivotal.io/partners/appdynamics/u
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v4.7.70</td>
+        <td>v4.7.74</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>July 17, 2019</td>
+        <td>July 19, 2019</td>
     </tr>
     <tr>
         <td>Pivotal Cloud Foundry Operations Manager </td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -35,7 +35,7 @@ and [language-specific workflows](https://docs.pivotal.io/partners/appdynamics/u
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v4.7.74</td>
+        <td>v4.7.81</td>
     </tr>
     <tr>
         <td>Release date</td>

--- a/docs-content/release_notes.html.md.erb
+++ b/docs-content/release_notes.html.md.erb
@@ -5,12 +5,13 @@ owner: Partners
 
 <p class="note"><strong>Note:</strong> Upgrades from AppDynamics v1.x are not supported. If you previously installed AppDynamics v1.x, uninstall it and install the latest version.</p>
 
-## <a id='4774'></a> 4.7.74
+## <a id='4774'></a> 4.7.81
 
 **Release Date:** July 19, 2019
 
 - Added advanced configuration option to override the name of the AppDynamics Service exported by AppDynamics Service Broker.
 The overridden name of the service must have `appdynamics` as prefix. 
+- Fixed missing image in MarketPlace UI
 
 ## <a id='4770'></a> 4.7.70
 

--- a/docs-content/release_notes.html.md.erb
+++ b/docs-content/release_notes.html.md.erb
@@ -12,7 +12,7 @@ owner: Partners
 - Added advanced configuration option to override the name of the AppDynamics Service exported by AppDynamics Service Broker.
 The overridden name of the service must have `appdynamics` as prefix. 
 
-## <a id='4767'></a> 4.7.67
+## <a id='4770'></a> 4.7.70
 
 **Release Date:** July 17, 2019
 

--- a/docs-content/release_notes.html.md.erb
+++ b/docs-content/release_notes.html.md.erb
@@ -5,6 +5,13 @@ owner: Partners
 
 <p class="note"><strong>Note:</strong> Upgrades from AppDynamics v1.x are not supported. If you previously installed AppDynamics v1.x, uninstall it and install the latest version.</p>
 
+## <a id='4774'></a> 4.7.74
+
+**Release Date:** July 19, 2019
+
+- Added advanced configuration option to override the name of the AppDynamics Service exported by AppDynamics Service Broker.
+The overridden name of the service must have `appdynamics` as prefix. 
+
 ## <a id='4767'></a> 4.7.67
 
 **Release Date:** July 17, 2019


### PR DESCRIPTION
- Added advanced configuration option to override the name of the AppDynamics Service exported by AppDynamics Service Broker. The overridden  name of the service must have `appdynamics` as prefix. 